### PR TITLE
Fix loop range in negative weight cycle detection

### DIFF
--- a/07_Graph/Bellman Ford Algorithm/Detect Negative Weight Cycle in Graphs - Bellman Ford Algorithm.py
+++ b/07_Graph/Bellman Ford Algorithm/Detect Negative Weight Cycle in Graphs - Bellman Ford Algorithm.py
@@ -7,7 +7,7 @@ class Solution:
         dist = [2**31] * n
         dist[0] = 0
 
-        for i in range(n):
+        for i in range(n - 1):
             for j in range(len(edges)):
                 frm = edges[j][0]
                 to = edges[j][1]


### PR DESCRIPTION
This line ensures Bellman–Ford performs exactly the required number of relaxations (V–1) for correct shortest-path calculation and efficient negative-cycle detection.